### PR TITLE
支持docker容器部署

### DIFF
--- a/connect_pool_client.c
+++ b/connect_pool_client.c
@@ -58,12 +58,16 @@ static void* connect_pool_perisent(zval* zres, zval* data_source)
 {
     zend_resource sock_le;
     int ret;
+	char *pool_server;
     cpClient* cli = (cpClient*) pecalloc(sizeof (cpClient), 1, 1);
     if (cpClient_create(cli) < 0)
     {
         php_error_docref(NULL TSRMLS_CC, E_ERROR, "pdo_connect_pool: create sock fail. Error: %s [%d]", strerror(errno), errno);
     }
-    ret = cpClient_connect(cli, "127.0.0.1", 6253, (float) 100); //所有的操作100s超时
+	if(!(pool_server=getenv("POOL_SERVER"))){
+		 pool_server="127.0.0.1";
+	}
+    ret = cpClient_connect(cli, pool_server, 6253, (float) 100); //所有的操作100s超时
     if (ret < 0)
     {
         pefree(cli, 1);

--- a/cpServer.c
+++ b/cpServer.c
@@ -653,7 +653,7 @@ int static cpListen()
     setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &option, sizeof (int));
 
     bzero(&addr_in4, sizeof (addr_in4));
-    inet_pton(AF_INET, "127.0.0.1", &(addr_in4.sin_addr));
+    inet_pton(AF_INET, "0.0.0.0", &(addr_in4.sin_addr));
     addr_in4.sin_port = htons(CPGC.port);
     addr_in4.sin_family = AF_INET;
     ret = bind(sock, (struct sockaddr *) &addr_in4, sizeof (addr_in4));


### PR DESCRIPTION
1：服务端ip绑定改为0.0.0.0 ；
2：客户端连接地址改成可通过环境变量POOL_SERVER来设置(默认是127.0.0.1）；

这样改后可以把 pool_server ，php-fpm 部署在不同的容器里面，/var/run/cp  使用数据卷在两个容器里面共享 (注意： /var/run/cp 的权限需要 777  *建议这个改进一下，最好可以指定一个用户权限 )。