### PR TITLE
添加不需要依赖其他框架的类 TestSuite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,6 @@ COPY . /usr/src/php/ext/php-cp
 RUN docker-php-ext-install php-cp
 COPY ./pool.ini /etc/pool.ini
 
-# Workdir
+# workdir
 COPY . /usr/src/php-cp
 WORKDIR /usr/src/php-cp

--- a/README.md
+++ b/README.md
@@ -183,6 +183,18 @@ $rs = $obj1->exec($sql); //走主库
 $obj1->release();
 ```
 
+## 测试
+
+运行命令
+
+`php tests/RunTest.php --host 172.17.0.2 --class RedisTest --test test_set_get`
+
+ 执行测试，该命令接受三个参数：
+
++ --host 设置主机地址，可选，默认值为"127.0.0.1"
++ --class 设置要运行的测试类名称，可选，默认值为"RedisTest"
++ --test 设置要运行的测试函数名称，可选，如果不设置则执行所有测试
+
 ## contact us
 - http://weibo.com/u/2661945152
 - 83212019@qq.com

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -1,0 +1,29 @@
+<?php
+
+defined("PHPCP_TESTRUN") or die("使用 RunTest.php 运行测试!");
+
+require_once(dirname($_SERVER["PHP_SELF"])."/TestSuite.php");
+
+class RedisTest extends TestSuite {
+    public $redis;
+
+    public function setup()
+    {
+        $this->redis = new redisProxy();
+        $this->redis->connect($this->getHost());
+        $this->redis->select(5);
+    }
+
+    public function test_class_exists()
+    {
+        $this->assertTrue(class_exists("redisProxy"));
+    }
+
+    public function test_set_get()
+    {
+        $this->redis->set("phpcp", "hello world");
+        $this->assertEquals("hello world", $this->redis->get("phpcp"));
+    }
+}
+
+?>

--- a/tests/RunTest.php
+++ b/tests/RunTest.php
@@ -1,0 +1,26 @@
+<?php
+
+define("PHPCP_TESTRUN", true);
+
+require_once(dirname($_SERVER["PHP_SELF"])."/TestSuite.php");
+require_once(dirname($_SERVER["PHP_SELF"])."/RedisTest.php");
+
+/* 确保错误信息可以被正常输出到 stdout */
+error_reporting(E_ALL);
+ini_set("display_errors", "1");
+
+$args = getopt("", array("host:", "class:", "test:", "nocolors"));
+// $class = isset($args["class"]) ? strtolower($args["class"]) : "phpcp";
+$class = isset($args["class"]) ? $args["class"] : "RedisTest";
+$colorize = !isset($args["nocolors"]);
+$filter = isset($args["test"]) ? $args["test"] : NULL;
+$host = isset($args["host"]) ? $args["host"] : "127.0.0.1";
+
+TestSuite::flagColorization($colorize);
+
+echo "\n正在测试中，可能会花上一些时间，请耐心等待 :-)\n";
+echo "测试类 ";
+echo TestSuite::make_bold($class . ":\n");
+exit(TestSuite::run($class, $filter, $host));
+
+?>

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -1,0 +1,171 @@
+<?php
+
+defined("PHPCP_TESTRUN") or die("使用 RunTest.php 运行测试!");
+
+class TestSuite {
+    private $host;
+
+    private static $colorize = false;
+
+    private static $BOLD_ON = "\033[1m";
+    private static $BOLD_OFF = "\033[0m";
+    private static $BLACK = "\033[0;30m";
+    private static $DARKGRAY = "\033[1;30m";
+    private static $BLUE = "\033[0;34m";
+    private static $PURPLE = "\033[0;35m";
+    private static $GREEN = "\033[0;32m";
+    private static $YELLOW = "\033[0;33m";
+    private static $RED = "\033[0;31m";
+
+    public static $errors = array();
+    public static $warnings = array();
+
+    public function __construct($host) {
+        $this->host = $host;
+    }
+
+    public function getHost() {
+        return $this->host;
+    }
+
+    public static function make_bold($msg) {
+        return self::$colorize
+            ? self::$BOLD_ON . $msg . self::$BOLD_OFF
+            : $msg;
+    }
+
+    public static function make_success($str) {
+        return self::$colorize
+            ? self::$GREEN . $str . self::$BOLD_OFF
+            : $str;
+    }
+
+    public static function make_fail($str) {
+        return self::$colorize
+            ? self::$RED . $str . self::$BOLD_OFF
+            : $str;
+    }
+
+    public static function make_warning($str) {
+        return self::$colorize
+            ? self::$YELLOW . $str . self::$BOLD_OFF
+            : $str;
+    }
+
+    protected function assertFalse($bool) {
+        $this->assertTrue(!$bool);
+    }
+
+    protected function assertTrue($bool)
+    {
+        if ($bool) {
+            return;
+        }
+
+        $bt = debug_backtrace(false);
+        self::$errors[] = sprintf("断言失败: %s:%d (%s)\n",
+            $bt[0]["file"], $bt[0]["line"], $bt[1]["function"]);
+    }
+
+    protected function assertLess($a, $b) {
+        if($a < $b)
+            return;
+        $bt = debug_backtrace(false);
+        self::$errors[] = sprintf("断言失败 (%s >= %s): %s: %d (%s\n",
+            print_r($a, true), print_r($b, true),
+            $bt[0]["file"], $bt[0]["line"], $bt[1]["function"]);
+    }
+
+    protected function assertEquals($a, $b) {
+        if($a === $b)
+            return;
+        $bt = debug_backtrace(false);
+        self::$errors []= sprintf("断言失败 (%s !== %s): %s:%d (%s)\n",
+            print_r($a, true), print_r($b, true),
+            $bt[0]["file"], $bt[0]["line"], $bt[1]["function"]);
+    }
+
+    protected function markTestSkipped($msg="") {
+        $bt = debug_backtrace(false);
+        self::$warnings []= sprintf("跳过测试: %s:%d (%s) %s\n",
+            $bt[0]["file"], $bt[0]["line"], $bt[1]["function"], $msg);
+        throw new Exception($msg);
+    }
+
+    private static function getMaxTestLen($methods, $limit) {
+        $rv = 0;
+        $limit = strtolower($limit);
+        foreach ($methods as $method) {
+            $name = strtolower($method->name);
+            if (substr($name, 0, 4) != "test")
+                continue;
+            if ($limit && !strstr($name, $limit))
+                continue;
+            if (strlen($name) > $rv) {
+                $rv = strlen($name);
+            }
+        }
+        return $rv;
+    }
+
+    /* Flag colorization */
+    public static function flagColorization($override) {
+        self::$colorize = $override && function_exists("posix_isatty") &&
+            posix_isatty(STDOUT);
+    }
+
+    public static function run($className, $limit = NULL, $host = NULL) {
+        $limit = $limit ? strtolower($limit) : $limit;
+
+        $rc = new ReflectionClass($className);
+        $methods = $rc->getMethods(ReflectionMethod::IS_PUBLIC);
+        $max_len = self::getMaxTestLen($methods, $limit);
+
+        foreach ($methods as $method) {
+            $name = $method->name;
+
+            if (substr($name, 0, 4) !== "test") {
+                continue;
+            }
+
+            if ($limit && strstr(strtolower($name), $limit) === false) {
+                continue;
+            }
+
+            $out_name = str_pad($name, $max_len + 1);
+            echo self::make_bold($out_name);
+
+            $count = count($className::$errors);
+            $rt = new $className($host);
+
+            try {
+                $rt->setup();
+                $rt->$name();
+
+                if ($count === count($className::$errors)) {
+                    $msg = self::make_success("成功");
+                } else {
+                    $msg = self::make_fail("失败");
+                }
+            } catch (Exception $e) {
+                $className::$errors[] = "Uncaught exception '".$e->getMessage()."' ($name)\n";
+                $msg = self::make_fail("失败");
+            }
+
+            echo "[" . $msg . "]\n";
+        }
+
+        echo implode("", $className::$warnings) . "\n";
+
+        if (empty($className::$errors)) {
+            $msg = self::make_success("通过所有测试");
+            echo $msg . "\n\n";
+            return 0;
+        }
+
+        echo implode("", $className::$errors) . "\n";
+        return 1;
+    }
+}
+
+?>


### PR DESCRIPTION
在项目中添加不需要依赖phpunit框架的测试类，用于写项目测试。目前该类没有完成自动加载测试文件，需要手动加载和指定需要测试的文件。

运行后结果如下：

<img width="749" alt="2016-12-09 10 02 22" src="https://cloud.githubusercontent.com/assets/3501131/21034955/ba076e06-bdf6-11e6-8089-73e4bc4f34ca.png">

