### PR TITLE
docs: fix simple typo, propterty -> property

### DIFF
--- a/msgpack7/swoole_serialize.c
+++ b/msgpack7/swoole_serialize.c
@@ -498,7 +498,7 @@ try_again:
                 }
                 break;
             }
-                //object propterty table is this type
+                //object property table is this type
             case IS_INDIRECT:
                 data = Z_INDIRECT_P(data);
                 ((SBucketType*) (buffer->buffer + p))->data_type = Z_TYPE_P(data);


### PR DESCRIPTION
There is a small typo in msgpack7/swoole_serialize.c.

Should read `property` rather than `propterty`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md